### PR TITLE
Bump Markdown version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+1.x.x
+-----
+
+* Bumped version of Markdown used.
+
+
 1.0.1
 -----
 

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,1 +1,1 @@
-Markdown~=3.0.1
+Markdown~=3.1.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description='Creates and maintains a collection of subjects.',
     long_description='See the home page for more information.',
     install_requires=[
-        'markdown~=3.0.1',
+        'markdown~=3.1.1',
     ],
     url='https://github.com/unt-libraries/django-subjects',
     author='University of North Texas Libraries',


### PR DESCRIPTION
ping @ldko, this is just to bump the Markdown version to the latest, so as not to conflict with higher restrictions on the package from other apps in digital2