### PR TITLE
Add exception for getting a subject that does not exist

### DIFF
--- a/subjects/traversal.py
+++ b/subjects/traversal.py
@@ -72,7 +72,7 @@ class TraversalUtils:
             ).order_by('name')
         elif subject_name != '' and subject_name is not None:
             # Grabs the row object of the given node
-            current_subject = subject.objects.get(name__exact=subject_name)
+            current_subject = get_object_or_404(subject, name__exact=subject_name)
             subject_id = current_subject.id
             # Grabs the children objects of the given node
             self.children_subjects = subject.objects.filter(

--- a/subjects/traversal.py
+++ b/subjects/traversal.py
@@ -1,5 +1,5 @@
 from django.db import DatabaseError
-from django.http import Http404
+from django.shortcuts import get_object_or_404
 
 
 class TraversalUtils:
@@ -64,11 +64,8 @@ class TraversalUtils:
 
         if subject_id != '' and subject_id is not None and subject_name == '':
             if subject_id != 0:
-                try:
-                    # Grabs the row object of the given node
-                    current_subject = subject.objects.get(id__exact=subject_id)
-                except subject.DoesNotExist:
-                    raise Http404('The subject does not exist.') 
+                # Grabs the row object of the given node
+                current_subject = get_object_or_404(subject, id__exact=subject_id) 
             # Grabs the children objects of the given node
             self.children_subjects = subject.objects.filter(
                 parent__exact=subject_id

--- a/subjects/traversal.py
+++ b/subjects/traversal.py
@@ -1,4 +1,5 @@
 from django.db import DatabaseError
+from django.http import Http404
 
 
 class TraversalUtils:
@@ -63,8 +64,11 @@ class TraversalUtils:
 
         if subject_id != '' and subject_id is not None and subject_name == '':
             if subject_id != 0:
-                # Grabs the row object of the given node
-                current_subject = subject.objects.get(id__exact=subject_id)
+                try:
+                    # Grabs the row object of the given node
+                    current_subject = subject.objects.get(id__exact=subject_id)
+                except subject.DoesNotExist:
+                    raise Http404('The subject does not exist.') 
             # Grabs the children objects of the given node
             self.children_subjects = subject.objects.filter(
                 parent__exact=subject_id

--- a/subjects/traversal.py
+++ b/subjects/traversal.py
@@ -65,7 +65,7 @@ class TraversalUtils:
         if subject_id != '' and subject_id is not None and subject_name == '':
             if subject_id != 0:
                 # Grabs the row object of the given node
-                current_subject = get_object_or_404(subject, id__exact=subject_id) 
+                current_subject = get_object_or_404(subject, id__exact=subject_id)
             # Grabs the children objects of the given node
             self.children_subjects = subject.objects.filter(
                 parent__exact=subject_id

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -46,6 +46,10 @@ class TestBrowseSubjects:
         assert sub in response.context['browse_nav']
         assert response.context['browse_string'] == sub.name
 
+    def test_browse_subject_with_nonexisting_id(self, client):
+        response = client.get(reverse('browse', kwargs={'sub_id': 1}))
+        assert response.status_code == 404
+
 
 @pytest.mark.django_db
 class TestSearchSubjects:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -50,6 +50,10 @@ class TestBrowseSubjects:
         response = client.get(reverse('browse', kwargs={'sub_id': 1}))
         assert response.status_code == 404
 
+    def test_browse_subject_with_nonexisting_name(self, client):
+        response = client.get(reverse('browse_sub_name', kwargs={'sub_name': 'testname'}))
+        assert response.status_code == 404
+
 
 @pytest.mark.django_db
 class TestSearchSubjects:


### PR DESCRIPTION
This fixes #17. This adds the exception for when a subject does not exist with the subject ID that was provided in the URL and lets the user know.